### PR TITLE
Modify to use with langchain openai compatible model

### DIFF
--- a/lg_pentest/pentest_agent/requirements.txt
+++ b/lg_pentest/pentest_agent/requirements.txt
@@ -4,3 +4,4 @@ tavily-python
 langchain_community
 langchain_openai
 langchain
+langchain_core

--- a/lg_pentest/pentest_agent/utils/model.py
+++ b/lg_pentest/pentest_agent/utils/model.py
@@ -1,14 +1,12 @@
-# from langchain_groq import ChatGroq
-# from langchain_mistralai import ChatMistralAI
+from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 
-# model = ChatMistralAI(model='mistral-large-latest')
-# model = ChatGroq(model='llama-3.1-8b-instant')
-model = ChatAnthropic(
-    # model="claude-3-haiku-20240307",
-    model="claude-3-5-sonnet-20240620",
-)
+def _get_model(model_name: str = "openai"):
+    if model_name == "anthropic":
+        model = ChatAnthropic(temperature=0, model_name="claude-3-5-sonnet-20240620")
+    elif model_name == "openai":
+        model = ChatOpenAI(temperature=0, model_name="gpt-4")
+    else:
+        raise ValueError(f"Unsupported model type: {model_name}")
 
-def _get_model():
     return model
-


### PR DESCRIPTION
Modify `_get_model` function to support both "anthropic" and "openai" models, with "openai" as the default.

* **Model Support**:
  - Add import for `ChatOpenAI` from `langchain_openai`.
  - Modify `_get_model` function to support both "anthropic" and "openai" models, with "openai" as the default.
  - Remove hardcoded `ChatAnthropic` model instantiation.

* **Requirements**:
  - Add `langchain_core` to `requirements.txt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snow10100/pena/pull/14?shareId=a77a6d30-7e9c-4a89-80ae-f6a3b5807e57).